### PR TITLE
CI: Add Windows Arm64 job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,6 +22,7 @@ jobs:
           i686-pc-windows-msvc,
           x86_64-pc-windows-gnu,
           x86_64-pc-windows-msvc,
+          aarch64-pc-windows-msvc
         ]
         channel: [ nightly ]
         include:


### PR DESCRIPTION
Adds a job targeting aarch64-pc-windows-msvc to the test matrix.